### PR TITLE
Exclude token tracing when streaming in order to prevent any exception

### DIFF
--- a/apim-policy.xml
+++ b/apim-policy.xml
@@ -209,7 +209,7 @@
             </choose>
             <!-- Prepare the tokens correlation info -->
 			<choose>
-				<when condition="@(context.Response != null && context.Response.StatusCode == 200)">
+				<when condition="@(context.Response != null && context.Response.StatusCode == 200 && context.Response.Headers.GetValueOrDefault("Content-Type","") != "text/event-stream")">
 					<set-variable name="tokens" value="@{
                         var responseBody = context.Response.Body.As<JObject>(preserveContent: true);
 


### PR DESCRIPTION
When using this policy with the streaming of a chat completion, i.e. with this code:
  ```
var client = new OpenAIClient(new Uri(configuration["OpenAI:Endpoint"]), new AzureKeyCredential(configuration["OpenAI:Key"]), new OpenAIClientOptions { });
  var chatCompletionsOptions = new ChatCompletionsOptions()
  {
      DeploymentName = configuration["OpenAI:Deployment"],
      Messages =
      {      
        new ChatRequestUserMessage("What's the best way to train a parrot?"),
    }
};

await foreach (StreamingChatCompletionsUpdate chatUpdate in client.GetChatCompletionsStreaming(chatCompletionsOptions))
{
    if (chatUpdate.Role.HasValue)
    {
        Console.Write($"{chatUpdate.Role.Value.ToString().ToUpperInvariant()}: ");
    }
    if (!string.IsNullOrEmpty(chatUpdate.ContentUpdate))
    {
        Console.Write(chatUpdate.ContentUpdate);
    }
}
```
a 500 error is raised from the APIM because some expected JSON parsing for count the token is not applicable, following the exception:
"expression evaluation failed. The message body is not a valid JSON. Unexpected character encountered while parsing value: d. Path '', line 0, position 0."

This PR will skip the tracing of the token in that case.
